### PR TITLE
Proper usage of json

### DIFF
--- a/apps/RESTAPI/controllers.py
+++ b/apps/RESTAPI/controllers.py
@@ -1,5 +1,3 @@
-import json
-
 from flask import Blueprint, request
 
 from apps.RESTAPI.response_builders import to_multiple_user_response, to_multiple_post_response, \
@@ -66,8 +64,9 @@ def get_user_by_id(user_id, query: QueryUserByID):
 
 
 @openchat_controllers.route('/users', methods=['GET'])
+@return_json
 def get_all_users(query: QueryAllUsers):
-    return json.dumps(to_multiple_user_response(query.execute())), 200
+    return to_multiple_user_response(query.execute()), 200
 
 
 @openchat_controllers.route('/users/<user_id>/timeline', methods=['POST'])
@@ -100,6 +99,7 @@ def get_user_wall(query: QueryWallByUserID, user_id):
 
 
 @openchat_controllers.route('/followings', methods=['POST'])
+@return_json
 def followings_post(command_bus: CommandBus):
     client_request = request.json
     validate_client_request(client_request, ['followerId', 'followeeId'])

--- a/apps/RESTAPI/error_handler.py
+++ b/apps/RESTAPI/error_handler.py
@@ -1,4 +1,13 @@
+import json
+
+from flask import Response
+
+
 def handle_invalid_usage(error: ValueError):
     status_code = 400
-    response_body = """{"application_error": {"status_code": %d ,"message": "%s"}}""" % (status_code, error.__str__())
-    return response_body, status_code
+    response_body = {"application_error": {"status_code": status_code, "message": error.__str__()}}
+    response = Response(response=json.dumps(response_body),
+                        status=status_code,
+                        mimetype='application/json'
+                        )
+    return response

--- a/apps/RESTAPI/tools.py
+++ b/apps/RESTAPI/tools.py
@@ -1,7 +1,8 @@
 import functools
+import json
 from typing import List, Callable
 
-from flask import jsonify
+from flask import Response
 from injector import Injector
 
 from domain.misc import CommandBus, EventBus
@@ -35,6 +36,11 @@ def return_json(view):
     @functools.wraps(view)
     def wrapped_view(**values):
         response, status = view(**values)
-        return jsonify(response), status
+        response = Response(
+            response=json.dumps(response),
+            status=status,
+            mimetype='application/json'
+        )
+        return response
 
     return wrapped_view

--- a/tests/apps/RESTAPI/test_login_requests.py
+++ b/tests/apps/RESTAPI/test_login_requests.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from apps.RESTAPI.__main__ import create_openchat_app
@@ -11,18 +10,18 @@ class TestLoginRequests(TestCase):
         self.client = self.app.test_client()
 
     def test_can_login_a_user(self):
-        self.client.post('/users', json=json.loads("""{
-                "username" : "Alice",
-                "password" : "alki324d",
-                "about" : "I love playing the piano and travelling."
-            }"""))
+        self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        })
 
-        response = self.client.post('/login', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d"
-    }"""))
+        response = self.client.post('/login', json={
+            "username": "Alice",
+            "password": "alki324d"
+        })
 
-        json_response = json.loads(response.get_data(as_text=True))
+        json_response = response.get_json()
 
         self.assertEqual(200, response.status_code)
         self.assertEqual("Alice", json_response['username'])
@@ -30,9 +29,9 @@ class TestLoginRequests(TestCase):
         self.assertTrue(validate_uuid4_string(json_response['id']))
 
     def test_login_users_bad_parameters_results_in_bad_request(self):
-        response = self.client.post('/login', json=json.loads("""{}"""))
+        response = self.client.post('/login', json={})
 
-        json_response = json.loads(response.get_data(as_text=True))
+        json_response = response.get_json()
 
         self.assertEqual(400, response.status_code)
         self.assertIsNotNone(json_response['application_error'])

--- a/tests/apps/RESTAPI/test_post_requests.py
+++ b/tests/apps/RESTAPI/test_post_requests.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from apps.RESTAPI.__main__ import create_openchat_app
@@ -11,18 +10,18 @@ class TestPostsRequests(TestCase):
         self.client = self.app.test_client()
 
     def test_can_create_a_new_post(self):
-        register_response = self.client.post('/users', json=json.loads("""{
-                "username" : "Alice",
-                "password" : "alki324d",
-                "about" : "I love playing the piano and travelling."
-            }"""))
+        register_response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        })
 
-        registered_user = json.loads(register_response.get_data(as_text=True))
-        response = self.client.post('/users/%s/timeline' % registered_user['id'], json=json.loads("""{
-            "text" : "Hello everyone. I'm Alice."
-        }"""))
+        registered_user = register_response.get_json()
+        response = self.client.post('/users/%s/timeline' % registered_user['id'], json={
+            "text": "Hello everyone. I'm Alice."
+        })
 
-        json_response = json.loads(response.get_data(as_text=True))
+        json_response = response.get_json()
 
         self.assertEqual(201, response.status_code)
         self.assertEqual(registered_user['id'], json_response['userId'])
@@ -31,23 +30,22 @@ class TestPostsRequests(TestCase):
         self.assertTrue(validate_uuid4_string(json_response['postId']))
 
     def test_can_fetch_user_posts(self):
-        register_response = self.client.post('/users', json=json.loads("""{
-                "username" : "Alice",
-                "password" : "alki324d",
-                "about" : "I love playing the piano and travelling."
-            }"""))
+        register_response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        })
 
-        registered_user = json.loads(register_response.get_data(as_text=True))
-        create_post_response = self.client.post('/users/%s/timeline' % registered_user['id'], json=json.loads("""{
-            "text" : "Hello everyone. I'm Alice."
-        }"""))
+        registered_user = register_response.get_json()
+        create_post_response = self.client.post('/users/%s/timeline' % registered_user['id'], json={
+            "text": "Hello everyone. I'm Alice."
+        })
 
-        create_post_json_response = json.loads(create_post_response.get_data(as_text=True))
+        create_post_json_response = create_post_response.get_json()
 
         fetch_post_response = self.client.get('/users/%s/timeline' % registered_user['id'])
 
-        fetch_post_json_response = json.loads(fetch_post_response.get_data(as_text=True))
-
+        fetch_post_json_response = fetch_post_response.get_json()
         self.assertEqual(201, register_response.status_code)
         self.assertEqual(201, create_post_response.status_code)
         self.assertEqual(200, fetch_post_response.status_code)

--- a/tests/apps/RESTAPI/test_registration_requests.py
+++ b/tests/apps/RESTAPI/test_registration_requests.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from apps.RESTAPI.__main__ import create_openchat_app
@@ -11,13 +10,13 @@ class TestRegistrationRequests(TestCase):
         self.client = self.app.test_client()
 
     def test_can_register_a_user(self):
-        response = self.client.post('/users', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d",
-        "about" : "I love playing the piano and travelling."
-    }"""))
+        response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        })
 
-        json_response = json.loads(response.get_data(as_text=True))
+        json_response = response.get_json()
 
         self.assertEqual(201, response.status_code)
         self.assertEqual("Alice", json_response['username'])
@@ -25,9 +24,9 @@ class TestRegistrationRequests(TestCase):
         self.assertTrue(validate_uuid4_string(json_response['id']))
 
     def test_register_user_bad_parameters_results_in_bad_request(self):
-        response = self.client.post('/users', json=json.loads("""{}"""))
+        response = self.client.post('/users', json={})
 
-        json_response = json.loads(response.get_data(as_text=True))
+        json_response = response.get_json()
 
         self.assertEqual(400, response.status_code)
         self.assertIsNotNone(json_response['application_error'])

--- a/tests/apps/RESTAPI/test_requests.py
+++ b/tests/apps/RESTAPI/test_requests.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from apps.RESTAPI.__main__ import create_openchat_app
@@ -10,9 +9,9 @@ class TestRegistrationRequests(TestCase):
         self.client = self.app.test_client()
 
     def test_should_return_bar_request_on_invalid_body_format(self):
-        error_response = self.client.post('/users', json=json.loads("""[]"""))
+        error_response = self.client.post('/users', json=[])
         self.assertEqual(400, error_response.status_code)
 
-    def test_should_return_not_found_on_unexistent_resource(self):
-        error_response = self.client.post('/i_dont_exist', json=json.loads("""[]"""))
+    def test_should_return_not_found_on_inexistent_resource(self):
+        error_response = self.client.post('/i_dont_exist', json=[])
         self.assertEqual(404, error_response.status_code)

--- a/tests/apps/RESTAPI/test_user_requests.py
+++ b/tests/apps/RESTAPI/test_user_requests.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from apps.RESTAPI.__main__ import create_openchat_app
@@ -11,16 +10,16 @@ class TestRegistrationRequests(TestCase):
         self.client = self.app.test_client()
 
     def test_can_fetch_a_registered_user(self):
-        register_response = self.client.post('/users', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d",
-        "about" : "I love playing the piano and travelling."
-    }"""))
+        register_response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        })
 
-        register_json_response = json.loads(register_response.get_data(as_text=True))
+        register_json_response = register_response.get_json()
 
         query_user_response = self.client.get('/users/%s' % register_json_response['id'])
-        query_user_json_response = json.loads(register_response.get_data(as_text=True))
+        query_user_json_response = register_response.get_json()
 
         self.assertEqual(200, query_user_response.status_code)
         self.assertEqual("Alice", query_user_json_response['username'])
@@ -29,60 +28,58 @@ class TestRegistrationRequests(TestCase):
         self.assertTrue(validate_uuid4_string(query_user_json_response['id']))
 
     def test_can_fetch_all_users(self):
-        self.client.post('/users', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d",
-        "about" : "I love playing the piano and travelling."
-    }"""))
-        self.client.post('/users', json=json.loads("""{
-            "username" : "Maria",
-            "password" : "27398273",
-            "about" : "I love playing the chess and dancing."
-        }"""))
+        self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        })
+        self.client.post('/users', json={
+            "username": "Maria",
+            "password": "27398273",
+            "about": "I love playing the chess and dancing."
+        })
 
         query_user_response = self.client.get('/users')
-        query_user_json_response = json.loads(query_user_response.get_data(as_text=True))
+        query_user_json_response = query_user_response.get_json()
 
         self.assertEqual(200, query_user_response.status_code)
         self.assertEqual(2, len(query_user_json_response))
 
     def test_users_can_follow_other_users(self):
-        register_first_user_response = json.loads(self.client.post('/users', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d",
-        "about" : "I love playing the piano and travelling."
-    }""")).get_data(as_text=True))
-        register_second_user_response = json.loads(self.client.post('/users', json=json.loads("""{
-            "username" : "Maria",
-            "password" : "27398273",
-            "about" : "I love playing the chess and dancing."
-        }""")).get_data(as_text=True))
+        register_first_user_response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        }).get_json()
+        register_second_user_response = self.client.post('/users', json={
+            "username": "Maria",
+            "password": "27398273",
+            "about": "I love playing the chess and dancing."
+        }).get_json()
 
-        follow_response = self.client.post("/followings", json=json.loads('{"followerId" : "%s","followeeId" : "%s"}' %
-                                                                          (register_first_user_response['id'],
-                                                                           register_second_user_response['id'])))
+        follow_response = self.client.post("/followings", json={"followerId": register_first_user_response['id'],
+                                                                "followeeId": register_second_user_response['id']})
 
         self.assertEqual(201, follow_response.status_code)
 
     def test_can_fetch_followers(self):
-        register_first_user_response = json.loads(self.client.post('/users', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d",
-        "about" : "I love playing the piano and travelling."
-    }""")).get_data(as_text=True))
-        register_second_user_response = json.loads(self.client.post('/users', json=json.loads("""{
-            "username" : "Maria",
-            "password" : "27398273",
-            "about" : "I love playing the chess and dancing."
-        }""")).get_data(as_text=True))
+        register_first_user_response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        }).get_json()
+        register_second_user_response = self.client.post('/users', json={
+            "username": "Maria",
+            "password": "27398273",
+            "about": "I love playing the chess and dancing."
+        }).get_json()
 
-        follow_response = self.client.post("/followings", json=json.loads('{"followerId" : "%s","followeeId" : "%s"}' %
-                                                                          (register_first_user_response['id'],
-                                                                           register_second_user_response['id'])))
+        follow_response = self.client.post("/followings", json={"followerId": register_first_user_response['id'],
+                                                                "followeeId": register_second_user_response['id']})
 
         followees_response = self.client.get("/followings/%s/followees" % register_first_user_response['id'])
 
-        followees_json_response = json.loads(followees_response.get_data(as_text=True))
+        followees_json_response = followees_response.get_json()
         self.assertEqual(201, follow_response.status_code)
         self.assertEqual(200, followees_response.status_code)
 
@@ -90,31 +87,29 @@ class TestRegistrationRequests(TestCase):
         self.assertEqual(followees_json_response[0]['id'], register_second_user_response['id'])
 
     def test_can_fetch_the_wall(self):
-        register_first_user_response = json.loads(self.client.post('/users', json=json.loads("""{
-        "username" : "Alice",
-        "password" : "alki324d",
-        "about" : "I love playing the piano and travelling."
-    }""")).get_data(as_text=True))
-        register_second_user_response = json.loads(self.client.post('/users', json=json.loads("""{
-            "username" : "Maria",
-            "password" : "27398273",
-            "about" : "I love playing the chess and dancing."
-        }""")).get_data(as_text=True))
+        register_first_user_response = self.client.post('/users', json={
+            "username": "Alice",
+            "password": "alki324d",
+            "about": "I love playing the piano and travelling."
+        }).get_json()
+        register_second_user_response = self.client.post('/users', json={
+            "username": "Maria",
+            "password": "27398273",
+            "about": "I love playing the chess and dancing."
+        }).get_json()
 
-        follow_response = self.client.post("/followings", json=json.loads('{"followerId" : "%s","followeeId" : "%s"}' %
-                                                                          (register_first_user_response['id'],
-                                                                           register_second_user_response['id'])))
-
+        follow_response = self.client.post("/followings", json={"followerId": register_first_user_response['id'],
+                                                                "followeeId": register_second_user_response['id']})
         followees_response = self.client.get("/followings/%s/followees" % register_first_user_response['id'])
 
-        followees_json_response = json.loads(followees_response.get_data(as_text=True))
+        followees_json_response = followees_response.get_json()
 
         self.client.post('/users/%s/timeline' % register_second_user_response['id'],
-                         json=json.loads("""{"text" : "Hello everyone. I'm Maria."}"""))
+                         json={"text": "Hello everyone. I'm Maria."})
 
         wall_response = self.client.get("/users/%s/wall" % register_first_user_response['id'])
 
-        wall_json_response = json.loads(wall_response.get_data(as_text=True))
+        wall_json_response = wall_response.get_json()
 
         self.assertEqual(201, follow_response.status_code)
         self.assertEqual(200, followees_response.status_code)


### PR DESCRIPTION
A dict is accepted as `json` parameter of `client` methods.
Serialize to JSON once on Responses.